### PR TITLE
Subclass: Get subclass from Inheritor class not location

### DIFF
--- a/blockapi/__init__.py
+++ b/blockapi/__init__.py
@@ -101,8 +101,8 @@ def get_all_supported_coins():
 
 
 def get_active_api_classes():
-    # inheritors = _inheritors(BlockchainAPI)
-    inheritors = _get_all_inheritors()
+    inheritors = _inheritors(BlockchainAPI)
+    # inheritors = _get_all_inheritors()
     return [i for i in inheritors if i.active]
 
 


### PR DESCRIPTION
After revision `ebe05e2`, only classes in the blockapi.api location are returned in `get_active_api_classes`. However, this isn't good for custom classes which is defined by user and inherited from `BlockchainAPI`. 