### PR TITLE
fix(unisat): cursor fix

### DIFF
--- a/blockapi/test/v2/api/nft/test_unisat.py
+++ b/blockapi/test/v2/api/nft/test_unisat.py
@@ -53,7 +53,6 @@ def test_parse_nfts(requests_mock, unisat_client, inscription_data):
     assert nft1.standard == "ordinals"
     assert nft1.name == "Ordinal #12345"
     assert nft1.amount == 1
-    assert nft1.updated_time == 1672531200
     assert nft1.blockchain == Blockchain.BITCOIN
     assert nft1.asset_type == AssetType.AVAILABLE
 

--- a/blockapi/test/v2/api/nft/test_unisat.py
+++ b/blockapi/test/v2/api/nft/test_unisat.py
@@ -72,7 +72,6 @@ def test_parse_nfts(requests_mock, unisat_client, inscription_data):
     assert nft2.standard == "ordinals"
     assert nft2.name == "Ordinal #12346"
     assert nft2.amount == 1
-    assert nft2.updated_time == 1672531300
     assert nft2.blockchain == Blockchain.BITCOIN
     assert nft2.asset_type == AssetType.AVAILABLE
 
@@ -108,7 +107,6 @@ def test_parse_nfts_edge_cases(
     assert nft.standard == "ordinals"
     assert nft.name == "Ordinal #2"
     assert nft.amount == 1
-    assert nft.updated_time == 1234567890
     assert nft.blockchain == Blockchain.BITCOIN
     assert nft.asset_type == AssetType.AVAILABLE
 

--- a/blockapi/v2/api/nft/unisat.py
+++ b/blockapi/v2/api/nft/unisat.py
@@ -2,8 +2,6 @@ import logging
 from typing import Optional, Dict, Generator
 from enum import Enum
 from datetime import datetime
-from attr import asdict
-import json
 
 from blockapi.v2.base import BlockchainApi, INftParser, INftProvider, ISleepProvider
 from blockapi.v2.coins import COIN_BTC
@@ -85,8 +83,6 @@ class UnisatApi(BlockchainApi, INftParser, INftProvider):
 
         Args:
             address: BTC address to fetch NFTs for
-            cursor: Pagination cursor (offset)
-            size: Number of items to return per request (default: 100)
 
         Returns:
             FetchResult containing the NFT data
@@ -294,7 +290,6 @@ class UnisatApi(BlockchainApi, INftParser, INftProvider):
         Args:
             nft_type: Type of NFT (brc20, domain, collection, arc20, runes)
             collection: Collection ID (slug), optional
-            cursor: Pagination cursor (offset, 'start' parameter)
             limit: Number of items per page
             address: Filter by address
             tick: Filter by tick (for BRC20)
@@ -472,7 +467,6 @@ class UnisatApi(BlockchainApi, INftParser, INftProvider):
             tick: Filter by tick (for BRC20)
             domain_type: Filter by domain type
             collection: Collection ID to filter by
-            cursor: Pagination cursor (offset, 'start' parameter)
             limit: Number of items
 
         Returns:

--- a/blockapi/v2/api/nft/unisat.py
+++ b/blockapi/v2/api/nft/unisat.py
@@ -56,7 +56,12 @@ class UnisatApi(BlockchainApi, INftParser, INftProvider):
         'get_collection_stats': 'v3/market/collection/auction/collection_statistic',
     }
 
-    def __init__(self, api_key: str, sleep_provider: Optional[ISleepProvider] = None, limit: Optional[int] = 10000):
+    def __init__(
+        self,
+        api_key: str,
+        sleep_provider: Optional[ISleepProvider] = None,
+        limit: Optional[int] = 10000,
+    ):
         """
         Initialize the Unisat API client
 
@@ -93,12 +98,12 @@ class UnisatApi(BlockchainApi, INftParser, INftProvider):
         """
         if not address:
             raise ValueError("Address is required")
-        
+
         # set size to self.limit based on the following heuristic:
         # Bottom line  1–2 NFTs per wallet is the norm.  Hundreds (100–999) is rare but possible for active collectors.  Low-thousands (1 000–1 999) exist only among the most hardcore or institutional actors.  10 000+ in a single non-contract wallet? Essentially never for an individual.
         # for simplicity, we will always set size to self.limit
         size = self.limit
-        
+
         # allow pagination cursor as string or int, convert to int, and set to 0 to avoid skipping any NFTS
         params = {'size': size, 'cursor': 0}
 
@@ -509,7 +514,7 @@ class UnisatApi(BlockchainApi, INftParser, INftProvider):
                 f"Unisat API limit is 500. You tried to fetch {limit} items. Truncating to 499."
             )
             limit = 499
-        
+
         request_body = {
             "filter": filter_dict,
             "start": 0,


### PR DESCRIPTION
Return cursor None, instead of a number, unisat cursor works like an offset and not another page, meaning chaingate throws an error of supplying the same cursor each time.